### PR TITLE
Fix media queries; add content to about-me

### DIFF
--- a/about-me.html
+++ b/about-me.html
@@ -32,14 +32,16 @@
     </body>
     <main>
         <section class="hero">
-            <h1>Welcome to My Learning Journal</h1>
+            <h1>Welcome to Mark's Learning Journal</h1>
             <h2>The CCNA Changed My Life</h2>
             <img src="/images/ccna.png">
         </section>
         <section class="blog blog-padding">
             <article>
                 <h3>The Start of my Learning Journey</h3>
-                <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Minus placeat, blanditiis quas officia pariatur provident recusandae facilis laudantium nam velit numquam fuga vel aliquid natus sit dolorum enim fugit praesentium.</p>
+                <p>
+                    It all began in June of 2024 when I had an unexpected and fateful reunion with an old acquaintance. They had recently passed the CCNA certification exam and, after some friendly small talk, they encouraged me to pursue the same path. Despite my initial doubts—having no prior knowledge of networking—and grappling with a mid-life crisis about my career direction, I took a leap of faith. Without overthinking it, I embarked on my journey to earn my first certification: the CCNA.
+                </p>
             </article>
         </section>
     </main>

--- a/styles/global.css
+++ b/styles/global.css
@@ -210,11 +210,6 @@ footer {
         padding: 1.75em;
     }
 
-    section.hero {
-        background-image: url("/images/article-image-hero-large.jpg");
-        min-height: 391px;
-    }
-
     section.hero > p {
         width: 70%;
     }

--- a/styles/index.css
+++ b/styles/index.css
@@ -38,3 +38,12 @@ time {
     margin-bottom: 0.5em;
 }
 
+/* Media Queries */
+
+@media (min-width: 620px) {
+
+    section.hero {
+        background-image: url("/images/article-image-hero-large.jpg");
+        min-height: 391px;
+    }
+}


### PR DESCRIPTION
- Fixed an issue in the media queries where the main blog hero image displayed incorrectly on all web pages for screen sizes of 620px or wider.

- Replaced placeholder content in the "About Me" section with relevant information.